### PR TITLE
Fix FileRepository constructor initialization

### DIFF
--- a/lib/repository/file_repository.dart
+++ b/lib/repository/file_repository.dart
@@ -10,7 +10,8 @@ final ioProvider= ChangeNotifierProvider( (ref) => FileRepository(model:ref.read
 
 class FileRepository extends ChangeNotifier{
   late NumberModel model;
-  FileRepository({required this.model}){
+  FileRepository({required NumberModel model}){
+    this.model = model;
     () async {
       final localPath = await getLocalPath;
       appPath = '$localPath/number/';


### PR DESCRIPTION
## Summary
- ensure `FileRepository` assigns passed `NumberModel` before async operations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d4e1d36883228cdfcda2cfe484ba