### PR TITLE
Update widget test to verify home page icons

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,11 @@ import 'package:formation_maker/ui/formation_maker.dart';
 
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Home page displays add and open buttons', (WidgetTester tester) async {
     await tester.pumpWidget(const FormationMakerApp());
+    await tester.pumpAndSettle();
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+    expect(find.byIcon(Icons.file_open), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- remove the default counter test
- verify that the home screen's add and open buttons appear

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d66d78e483229cbdacfc648d4df8