### PR TITLE
Update settings.gradle to new Flutter plugin format

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,11 +1,31 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        def propertiesFile = file("local.properties")
+        if (propertiesFile.exists()) {
+            propertiesFile.withReader("UTF-8") { reader ->
+                properties.load(reader)
+            }
+        }
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+        def sdkPath = properties.getProperty("flutter.sdk")
+        if (sdkPath == null) {
+            throw new GradleException("flutter.sdk not set in local.properties")
+        }
+        return sdkPath
+    }()
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
+include ":app"


### PR DESCRIPTION
## Summary
- migrate `android/settings.gradle` to use the modern Flutter plugin management configuration
- load the Flutter Gradle plugin via `dev.flutter.flutter-gradle-plugin` instead of legacy script application

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce739f8fec8322b050a163f0b18a06