### PR TITLE
Align dependency constraints with resolved versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,15 +35,15 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  flutter_riverpod: ^1.0.0-dev.7 # 2023/07/24 Riverpod追加
+  flutter_riverpod: ^1.0.4 # 2023/07/24 Riverpod追加
   json_annotation: ^4.8.1
   path_provider: ^2.0.15
-  flutter_hooks:
-  hooks_riverpod:
-  intl:
+  flutter_hooks: ^0.18.6
+  hooks_riverpod: ^1.0.4
+  intl: ^0.18.1
   flutter_file_dialog: ^3.0.1
   fluttertoast: ^8.2.2
-  loading_animation_widget:
+  loading_animation_widget: ^1.2.0+4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- pin the flutter_riverpod dependency to the stable 1.0.4 release
- add explicit version ranges for flutter_hooks, hooks_riverpod, intl, and loading_animation_widget to match the resolved lockfile

## Testing
- flutter test *(fails: `flutter` command not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce78d6792883228c0a7bdae1f161f6